### PR TITLE
🔨 Refr: System instances now init plants within stars

### DIFF
--- a/helpers/system.py
+++ b/helpers/system.py
@@ -11,10 +11,10 @@ class System():
     def __init__(self, stellar_body):
         self.name: str = stellar_body
         self._stars: list = []
-        self._planets: list = []
+        self._num_planets = 0
 
         self._generate_stars()
-        self._generate_planets()
+        self._set_num_planets()
 
     # used for checking equality in a set
     def __hash__(self):
@@ -121,34 +121,15 @@ class System():
 # *****************************
 
 
-# Set: system.planets
+# Set: system._num_planets
 # *****************************
     @property
-    def planets(self) -> list:
-        return self._planets
+    def num_planets(self) -> int:
+        return self._num_planets
     
-    def _generate_planets(self):
-        """Generate planets by stars from self.stars"""
-        planets = []
-        with sqlite3.connect(System.DB) as conn:
-            for star in self.stars:
-                cursor = conn.cursor()
-                query = f"""
-                    SELECT pl_name
-                    FROM {System.TABLES[0]}
-                    WHERE hostname=?;
-                """
-                cursor.execute(query, (star.name,))
-                results = cursor.fetchall()
-
-                for result in results:
-                    planets.append(result[0])
-
-                cursor.close()
-
-            # raise TypeError(f"planets = {planets}")
-
-        for planet in planets:
-            planet_details = Planet(planet, system=self.name)
-            self._planets.append(planet_details)
+    def _set_num_planets(self) -> None:
+        count = 0
+        for star in self.stars:
+            count += len(star.planets)
+        self._num_planets = count
 # *****************************

--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ def system(stellar_body=None):
         # if no reference to system by redirect
         return redirect(url_for('suggestions', search=stellar_body), code=302)
 
-    size = len(system.planets) + len(system.stars)
+    size = system.num_planets + len(system.stars)
 
     return render_template("system.html", system=system, size=size)
 

--- a/templates/new_planets.html
+++ b/templates/new_planets.html
@@ -8,11 +8,11 @@
         <thead>
             <tr>
                 <th></th>
-                <th>Planet Name</th>
-                <th>Host</th>
-                <th>System</th>
-                <th>Circumbinary?</th>
-                <th>Public Discovery Date</th>
+                <th>🪐Planet Name🪐</th>
+                <th>☀️Host☀️</th>
+                <th>🌌System🌌</th>
+                <th>💫Circumbinary?💫</th>
+                <th>📡Public Discovery Date📡</th>
             </tr>
         </thead>
         <tbody>

--- a/templates/star.html
+++ b/templates/star.html
@@ -14,9 +14,9 @@
 <div>
     <p>
         {% if star.name == star.system %}
-            <b>'{{ star.name }}'</b> is the main star in its <a href="{{ url_for('system', stellar_body=star.system) }}">system.</a>
+            <b>'{{ star.name }}'</b> is the main star in its system <a href="{{ url_for('system', stellar_body=star.system) }}"><b>'{{ star.name }}'.</b></a>
         {% else %}
-            <b>'{{ star.name }}'</b> is found in the <a href="{{ url_for('system', stellar_body=star.system) }}"><b>'{{ star.system }}'</b></a>System.
+            <b>'{{ star.name }}'</b> is found in the <a href="{{ url_for('system', stellar_body=star.system) }}"><b>'{{ star.system }}'</b></a> system.
         {% endif %}
     </p>
 </div>
@@ -59,4 +59,25 @@
         </tbody>
     </table>
 </div>
+<br>
+{% if star.planets %}
+<div class="table-star-planets">
+    <table>
+        <thead>
+            <tr>
+                <th>
+                    <h3>🪐Planets🪐</h3>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for planet in star.planets %}
+            <tr>
+                <td><a href="{{ url_for('planet', planet_name=planet.name) }}">{{ planet.name }}</a></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
 {% endblock %}

--- a/templates/system.html
+++ b/templates/system.html
@@ -17,11 +17,9 @@
                     <h2>
                         🌌{{ system.name }}🌌<br>
                         {% for star in system.stars %}
-                        ☀️
+                            ☀️
                         {% endfor %}
-                        {% for planet in system.planets %}
-                        🪐
-                        {% endfor %}
+                        {{ '🪐' * system.num_planets }}
                     </h2>
                 </th>
             </tr>
@@ -29,7 +27,7 @@
         <thead>
             <tr>
                 <th colspan="{{ system.stars|length + 1}}">Stars</th>
-                <th colspan="{{ system.planets|length + 1 }}">Planets</th>
+                <th colspan="{{ system.num_planets + 1 }}">Planets</th>
             </tr>
         </thead>
         <tbody>
@@ -39,7 +37,7 @@
                 <td>☀️</td>
                 {% endfor %}
                 <td></td>
-                {% for planet in system.planets %}
+                {% for _ in range(system.num_planets) %}
                 <td>🪐</td>
                 {% endfor %}
             </tr>
@@ -49,10 +47,12 @@
                 <td class="nowrap"><a href="{{ url_for('star', star_name=star.name) }}">{{ star.name }}</a></td>
                 {% endfor %}
                 <td class="catagory">Name</td>
-                {% for planet in system.planets %}
-                {% if planet.declassified != 'Yes' %}
-                <td class="nowrap"><a href="{{ url_for('planet', planet_name=planet.name) }}">{{ planet.name }}</a></td>
-                {% endif %}
+                {% for star in system.stars %}
+                    {% for planet in star.planets %}
+                        {% if planet.declassified != 'Yes' %}
+                            <td class="nowrap"><a href="{{ url_for('planet', planet_name=planet.name) }}">{{ planet.name }}</a></td>
+                        {% endif %}
+                    {% endfor%}
                 {% endfor %}
             </tr>
             <tr>
@@ -61,10 +61,12 @@
                 <td>{{ star.full_class_id }}</td>
                 {% endfor %}
                 <td class="catagory">Host Star</td>
-                {% for planet in system.planets %}
-                {% if planet.declassified != 'Yes' %}
-                <td>{{ planet.hostname }}</td>
-                {% endif %}
+                {% for star in system.stars %}
+                    {% for planet in star.planets %}
+                        {% if planet.declassified != 'Yes' %}
+                            <td>{{ planet.hostname }}</td>
+                        {% endif %}
+                    {% endfor %}
                 {% endfor %}
             </tr>
             <tr>
@@ -77,10 +79,12 @@
                 </td>
                 {% endfor %}
                 <td class="catagory">Circumbinary</td>
-                {% for planet in system.planets %}
-                {% if planet.declassified != 'Yes' %}
-                <td>{{ planet.cb_flag }}</td>
-                {% endif %}
+                {% for star in system.stars %}
+                    {% for planet in star.planets %}
+                        {% if planet.declassified != 'Yes' %}
+                            <td>{{ planet.cb_flag }}</td>
+                        {% endif %}
+                    {% endfor %}
                 {% endfor %}
             </tr>
             <tr>
@@ -93,10 +97,12 @@
                 </td>
                 {% endfor %}
                 <td class="catagory">Discovery Year<br>(Published)</td>
-                {% for planet in system.planets %}
-                {% if planet.declassified != 'Yes' %}
-                <td>{{ planet.disc_pubdate }}</td>
-                {% endif %}
+                {% for star in system.stars %}
+                    {% for planet in star.planets %}
+                        {% if planet.declassified != 'Yes' %}
+                            <td>{{ planet.disc_pubdate }}</td>
+                        {% endif %}
+                    {% endfor %}
                 {% endfor %}
             </tr>
             <tr>
@@ -109,12 +115,13 @@
                 </td>
                 {% endfor %}
                 <td class="catagory"></td>
-                {% for planet in system.planets %}
-                {% if planet.declassified != 'Yes' %}
-                <td>
-                </td>
-                {% endif %}
-                {% endfor %}     
+                {% for star in system.stars %}
+                    {% for planet in star.planets %}
+                        {% if planet.declassified != 'Yes' %}
+                            <td></td>
+                        {% endif %}
+                    {% endfor %}
+                {% endfor %}    
             </tr>
         </tbody>
     </table>

--- a/templates/system_updates.html
+++ b/templates/system_updates.html
@@ -8,18 +8,18 @@
         <thead>
             <tr>
                 <th></th>
-                <th>System Name</th>
-                <th>Star Count</th>
-                <th>Planet Count</th>
+                <th>🌌System Name🌌</th>
+                <th>☀️Star Count☀️</th>
+                <th>🪐Planet Count🪐</th>
             </tr>
         </thead>
         <tbody>
             {% for system in new_systems %}
             <tr>
-                <td class="nowrap">{% for star in system.stars %}☀️{% endfor%}{% for planet in system.planets %}🪐{% endfor%}</td>
+                <td class="nowrap">{% for star in system.stars %}☀️{% endfor%}{% for _ in range(system.num_planets) %}🪐{% endfor%}</td>
                 <td class="nowrap"><a href="{{ url_for('system', stellar_body=system.name) }}">{{ system.name }}</a></td>
                 <td>{{ system.stars|length }}</td>
-                <td>{{ system.planets|length }}</td>
+                <td>{{ system.num_planets }}</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
When Star instances init they now create planet instance variables. This means that when creating a system instance and stars are generated, they generate their own planets.

Planet instance generation has been removed from System instances Star instances generate planet instances

All object referencing throughout the website has been upated to remove old system.planets references and now alike to system.star.planets